### PR TITLE
Deal with empty `mostRecentMessages`

### DIFF
--- a/dist/SlackAPI.js
+++ b/dist/SlackAPI.js
@@ -122,7 +122,9 @@ var SlackAPI = function (_EventEmitter) {
             var endpoint = 'channels.mark';
             if (channel.is_im) endpoint = 'im.mark';else if (channel.is_private) endpoint = 'groups.mark';else if (channel.is_mpim) endpoint = 'mpim.mark';
 
-            if (this.channels[channel.id] && this.channels[channel.id].history && this.channels[channel.id].history.messages) {
+            if (this.channels[channel.id] && this.channels[channel.id].history && this.channels[channel.id].history.messages && this.channels[channel.id].history.messages.some(function (m) {
+                return typeof m.ts !== 'undefined';
+            })) {
                 var mostRecentMessages = this.channels[channel.id].history.messages.filter(function (m) {
                     return typeof m.ts !== 'undefined';
                 }).sort(function (a, b) {

--- a/src/SlackAPI.js
+++ b/src/SlackAPI.js
@@ -107,7 +107,7 @@ export default class SlackAPI extends EventEmitter {
         else if (channel.is_private) endpoint = 'groups.mark';
         else if (channel.is_mpim) endpoint = 'mpim.mark';
 
-        if (this.channels[channel.id] && this.channels[channel.id].history && this.channels[channel.id].history.messages) {
+        if (this.channels[channel.id] && this.channels[channel.id].history && this.channels[channel.id].history.messages && this.channels[channel.id].history.messages.some(m => typeof m.ts !== 'undefined')) {
             let mostRecentMessages = this.channels[channel.id].history.messages.filter(m => typeof m.ts !== 'undefined').sort((a, b) => {
                 let ats = 0;
                 let bts = 0;


### PR DESCRIPTION
In a situation where the messages are not empty, but the messages
with valid timestamps are, ensure timestamps are not accessed.