### PR TITLE
Terminal base16 colors

### DIFF
--- a/dist/Channel.js
+++ b/dist/Channel.js
@@ -34,9 +34,8 @@ var ChannelBox = function () {
             },
             style: {
                 fg: 'white',
-                bg: 'black',
                 border: {
-                    fg: '#f0f0f0'
+                    fg: 'yellow',
                 }
             }
         });

--- a/dist/ChannelsList.js
+++ b/dist/ChannelsList.js
@@ -65,9 +65,8 @@ var ChannelsList = function (_EventEmitter) {
             },
             style: {
                 fg: 'white',
-                bg: 'black',
                 border: {
-                    fg: '#f0f0f0'
+                    fg: 'yellow',
                 },
                 hover: {
                     bg: 'green'

--- a/dist/MessageForm.js
+++ b/dist/MessageForm.js
@@ -27,7 +27,6 @@ var MessageForm = function () {
             bottom: 0,
             width: '100%-2',
             height: 4,
-            bg: 'black'
             // border: {type: 'line'}
         });
 
@@ -37,14 +36,12 @@ var MessageForm = function () {
             top: 0,
             width: '100%',
             height: 4,
-            bg: 'black',
-            fg: 'white',
             input: true,
             mouse: true,
             keys: true,
             inputOnFocus: true,
             label: 'Write Message (Ctrl-o)',
-            border: { type: 'line' }
+            border: { type: 'line', fg: 'yellow' },
         });
 
         this.textbox.key('enter', function (ch, key) {

--- a/dist/MessagesList.js
+++ b/dist/MessagesList.js
@@ -39,10 +39,8 @@ var MessagesList = function () {
                 inverse: true
             },
             style: {
-                fg: 'white',
-                bg: 'black',
                 border: {
-                    fg: '#f0f0f0'
+                    fg: 'yellow',
                 }
             }
         });
@@ -110,7 +108,8 @@ var MessagesList = function () {
                 var userName = typeof m.user !== 'undefined' ? _this2.api.getUserName(m.user) : m.username ? m.username : 'Unknown User';
                 var time = moment.unix(m.ts);
                 var formattedTime = time.format('h:mma');
-                var content = '{bold}' + userName + '{/bold} ' + '{grey-fg}' + formattedTime + "{/grey-fg}: \n" + (m.text ? m.text : JSON.stringify(m));
+                var text = (m.text ? m.text : JSON.stringify(m));
+                var content = '{bold}{green-fg}' + userName + '{/bold}{/green-fg} ' + '{cyan-fg}' + formattedTime + "{/cyan-fg}: \n" + text;
                 for (var replaceId in userMap) {
                     var replaceName = userMap[replaceId];
                     content = content.replace(replaceId, replaceName);

--- a/dist/MessagesList.js
+++ b/dist/MessagesList.js
@@ -109,7 +109,10 @@ var MessagesList = function () {
                 var time = moment.unix(m.ts);
                 var formattedTime = time.format('h:mma');
                 var text = (m.text ? m.text : JSON.stringify(m));
-                var content = '{bold}{green-fg}' + userName + '{/bold}{/green-fg} ' + '{cyan-fg}' + formattedTime + "{/cyan-fg}: \n" + text;
+                var content = '{bold}{green-fg}' + userName 
+                + '{/bold}{/green-fg} ' 
+                + '{cyan-fg}' + formattedTime + "{/cyan-fg}: \n" 
+                + text;
                 for (var replaceId in userMap) {
                     var replaceName = userMap[replaceId];
                     content = content.replace(replaceId, replaceName);

--- a/src/Channel.js
+++ b/src/Channel.js
@@ -24,9 +24,8 @@ export default class ChannelBox {
             },
             style: {
                 fg: 'white',
-                bg: 'black',
                 border: {
-                    fg: '#f0f0f0'
+                    fg: 'yellow',
                 }
             }
         });

--- a/src/ChannelsList.js
+++ b/src/ChannelsList.js
@@ -46,9 +46,8 @@ export default class ChannelsList extends EventEmitter {
             },
             style: {
                 fg: 'white',
-                bg: 'black',
                 border: {
-                    fg: '#f0f0f0'
+                    fg: 'yellow',
                 },
                 hover: {
                     bg: 'green'

--- a/src/MessageForm.js
+++ b/src/MessageForm.js
@@ -14,7 +14,6 @@ export default class MessageForm {
             bottom: 0,
             width: '100%-2',
             height: 4,
-            bg: 'black',
             // border: {type: 'line'}
         });
 
@@ -24,14 +23,12 @@ export default class MessageForm {
             top: 0,
             width: '100%',
             height: 4,
-            bg: 'black',
-            fg: 'white',
             input: true,
             mouse: true,
             keys: true,
             inputOnFocus: true,
             label: 'Write Message (Ctrl-o)',
-            border: {type: 'line'}
+            border: {type: 'line', fg: 'yellow' }
         });
 
         this.textbox.key('enter', (ch, key) => {

--- a/src/MessagesList.js
+++ b/src/MessagesList.js
@@ -29,10 +29,8 @@ export default class MessagesList {
                 inverse: true
             },
             style: {
-                fg: 'white',
-                bg: 'black',
                 border: {
-                    fg: '#f0f0f0'
+                    fg: 'yellow',
                 }
             }
         });
@@ -90,9 +88,10 @@ export default class MessagesList {
                     ;
                     let time = moment.unix(m.ts);
                     let formattedTime = time.format('h:mma')
-                    let content = '{bold}'+userName + '{/bold} '
-                        + '{grey-fg}'+formattedTime+"{/grey-fg}: \n"
-                        + (m.text ? m.text : JSON.stringify(m));
+                    let text = (m.text ? m.text : JSON.stringify(m));
+                    let content = '{bold}{green-fg}'+userName + '{/bold}{green-fg} '
+                        + '{cyan-fg}'+formattedTime+"{/cyan-fg}: \n"
+                        + text;
                     for (const replaceId in userMap) {
                         const replaceName = userMap[replaceId];
                         content = content.replace(replaceId, replaceName);


### PR DESCRIPTION
The default colors was incompatible with my base16 terminal theme - and therefore I suspect it is incompatible with others too. (Unreadable text and weird background colors). 

I updated the colors to only use ANSI-colors, instead of hardcoded colors. Theme is inspired by [fb-messenger-cli](https://github.com/Alex-Rose/fb-messenger-cli)'s theme. 

Not sure if this is something you want - if not I'll be publishing an npm-package called slackadaisical-base16 for those who are interested. 