### PR TITLE
Add support for multiple workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,25 @@ You can install the token with the command `echo "YOUR_TOKEN" | tee ~/.slack_tok
 or simply paste that token into `~/.slack_token` and all will be well.
 
 ### Multi-Workspace Mode
-Slackadaisical supports multiple slack workspaces. Simply change your `~/.slack_token` file to a JSON file as per below:
+Slackadaisical supports multiple slack workspaces. Simply use a `~/.slackadaisical.json` file instead of a `~/.slack_token` file. In `~/.slackadaisical.json`, put the following (substituting your tokens for the `####`s).
 
 ```json
 {
-    "myWorkspace":        "xxx-slack-token-...",
-    "myOtherWorkspace":   "xxx-slack-token-...",
+    "workspaces": {
+        "workspace_one": {
+            "token": "####"
+        },
+        "workspace_two": {
+            "token": "####"
+        }
+    }
 }
+
 ```
 
 and then run:
 
-    $ slackadaisical myWorkspace
+    $ slackadaisical workspace_one
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -36,13 +36,27 @@ Once running, quit the app with Esc or Ctrl-C, and then restart with `npm start`
 Configuration
 -------------
 
-The app will yell at you if you don't install a file with your slack token in
-it.
+The app will yell at you if you don't install a file with your slack token in it.
 
 Visit https://api.slack.com/custom-integrations/legacy-tokens and generate a token for yourself.
 
-You can install the token with the command `echo "YOUR_TOKEN" | tee ~/.slack_token`, 
+You can install the token with the command `echo "YOUR_TOKEN" | tee ~/.slack_token`,
 or simply paste that token into `~/.slack_token` and all will be well.
+
+### Multi-Workspace Mode
+Slackadaisical supports multiple slack workspaces. Simply change your `~/.slack_token` file to a JSON file as per below:
+
+```json
+{
+    "myWorkspace":        "xxx-slack-token-...",
+    "myOtherWorkspace":   "xxx-slack-token-...",
+}
+```
+
+and then run:
+
+    $ slackadaisical myWorkspace
+
 
 Usage
 -----
@@ -51,7 +65,7 @@ Hit Escape or Ctrl-c to exit.
 
 **Navigating**: Hit Ctrl-l to jump to the channels list (j/k or arrows to move, Enter to select), Ctrl-o to compose (Enter to send), and Ctrl-y to jump to the channel messages history. Hit Esc to exit compose mode.
 
-**Mouse**: If your terminal supports mouse events, you may try clicking or scrolling in things. 
+**Mouse**: If your terminal supports mouse events, you may try clicking or scrolling in things.
 
 TODO: More stuff here.
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -11,17 +11,25 @@ try {
     var tokenFileContents = fs.readFileSync(tokenPath).toString().trim();
 
     try {
+        // Try to parse as JSON, where keys are workspace names
+        var data = JSON.parse(tokenFileContents);
+
+        // If that succeeds, then we need a workspace name
+        // which will be the last commandline arg. If we look
+        // for it and we get back the name of this executable,
+        // then the user forgot the workspace name.
         var wsName = process.argv.slice(-1)[0];
         if (wsName.endsWith("slackadaisical") || wsName.endsWith("index.js")) {
-            console.error("If using multi-workspace mode, you must specify a workspace with `slackadaisical [workspacename]`.");
+            console.error("If using multi-workspace mode, you must specify a workspace " + "with `slackadaisical [workspacename]`.");
             process.exit(1);
         }
 
-        // Try to parse as JSON, where keys are workspace names
-        var data = JSON.parse(tokenFileContents);
+        // If we CAN find that workspace name in the JSON,
+        // then set it as the token for this session.
         if (!!data[wsName]) {
             token = data[wsName];
         } else {
+            // Otherwise, warn the user and exit.
             console.log('Couldn\'t find workspace [' + wsName + '] in ~/.slack_token.');
             process.exit(1);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,28 @@ var tokenPath = process.env.HOME + '/.slack_token';
 var token = null;
 
 try {
-    token = fs.readFileSync(tokenPath).toString().trim();
+    var tokenFileContents = fs.readFileSync(tokenPath).toString().trim();
+
+    try {
+        var wsName = process.argv.slice(-1)[0];
+        if (wsName.endsWith("slackadaisical") || wsName.endsWith("index.js")) {
+            console.error("If using multi-workspace mode, you must specify a workspace with `slackadaisical [workspacename]`.");
+            process.exit(1);
+        }
+
+        // Try to parse as JSON, where keys are workspace names
+        var data = JSON.parse(tokenFileContents);
+        if (!!data[wsName]) {
+            token = data[wsName];
+        } else {
+            console.log('Couldn\'t find workspace [' + wsName + '] in ~/.slack_token.');
+            process.exit(1);
+        }
+    } catch (e) {
+        // Fall back to a file that contains only one token (for
+        // backwards compatibility)
+        token = tokenFileContents;
+    }
 } catch (e) {
     console.log("Could not find a slack token at " + tokenPath);
     process.exit(1);

--- a/src/index.js
+++ b/src/index.js
@@ -10,20 +10,31 @@ try {
     let tokenFileContents = fs.readFileSync(tokenPath).toString().trim();
 
     try {
+        // Try to parse as JSON, where keys are workspace names
+        let data = JSON.parse(tokenFileContents);
+
+        // If that succeeds, then we need a workspace name
+        // which will be the last commandline arg. If we look
+        // for it and we get back the name of this executable,
+        // then the user forgot the workspace name.
         let wsName = process.argv.slice(-1)[0];
         if (
             wsName.endsWith("slackadaisical") ||
             wsName.endsWith("index.js")
         ) {
-            console.error("If using multi-workspace mode, you must specify a workspace with `slackadaisical [workspacename]`.")
+            console.error(
+                "If using multi-workspace mode, you must specify a workspace " +
+                "with `slackadaisical [workspacename]`."
+            )
             process.exit(1);
         }
 
-        // Try to parse as JSON, where keys are workspace names
-        let data = JSON.parse(tokenFileContents);
+        // If we CAN find that workspace name in the JSON,
+        // then set it as the token for this session.
         if (!!data[wsName]) {
             token = data[wsName];
         } else {
+            // Otherwise, warn the user and exit.
             console.log(
                 `Couldn't find workspace [${wsName}] in ~/.slack_token.`
             );

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,33 @@ const tokenPath = process.env.HOME + '/.slack_token';
 let token = null;
 
 try {
-    token = fs.readFileSync(tokenPath).toString().trim();
+    let tokenFileContents = fs.readFileSync(tokenPath).toString().trim();
+
+    try {
+        let wsName = process.argv.slice(-1)[0];
+        if (
+            wsName.endsWith("slackadaisical") ||
+            wsName.endsWith("index.js")
+        ) {
+            console.error("If using multi-workspace mode, you must specify a workspace with `slackadaisical [workspacename]`.")
+            process.exit(1);
+        }
+
+        // Try to parse as JSON, where keys are workspace names
+        let data = JSON.parse(tokenFileContents);
+        if (!!data[wsName]) {
+            token = data[wsName];
+        } else {
+            console.log(
+                `Couldn't find workspace [${wsName}] in ~/.slack_token.`
+            );
+            process.exit(1);
+        }
+    } catch (e) {
+        // Fall back to a file that contains only one token (for
+        // backwards compatibility)
+        token = tokenFileContents;
+    }
 } catch (e) {
     console.log("Could not find a slack token at " + tokenPath);
     process.exit(1);

--- a/src/index.js
+++ b/src/index.js
@@ -2,53 +2,50 @@
 
 const fs = require('fs');
 const Slacker = require('./Slacker');
+const configPath = process.env.HOME + '/.slackadaisical.json';
 const tokenPath = process.env.HOME + '/.slack_token';
 
 let token = null;
 
+
 try {
-    let tokenFileContents = fs.readFileSync(tokenPath).toString().trim();
+    // Try to read the config file as JSON. Failing this will fall back to
+    // the old slack_token file.
+    let config = JSON.parse(fs.readFileSync(configPath).toString());
 
-    try {
-        // Try to parse as JSON, where keys are workspace names
-        let data = JSON.parse(tokenFileContents);
+    // Get the workspace name (the last arg from the CLI call)
+    let wsName = process.argv.slice(-1)[0];
+    if (
+        wsName.endsWith("slackadaisical") ||
+        wsName.endsWith("index.js")
+    ) {
+        // The user forgot to specify a workspace!
+        console.error(
+            "If using multi-workspace mode, you must specify a workspace " +
+            "with `slackadaisical [workspacename]`."
+        )
+        process.exit(1);
+    }
 
-        // If that succeeds, then we need a workspace name
-        // which will be the last commandline arg. If we look
-        // for it and we get back the name of this executable,
-        // then the user forgot the workspace name.
-        let wsName = process.argv.slice(-1)[0];
-        if (
-            wsName.endsWith("slackadaisical") ||
-            wsName.endsWith("index.js")
-        ) {
-            console.error(
-                "If using multi-workspace mode, you must specify a workspace " +
-                "with `slackadaisical [workspacename]`."
-            )
-            process.exit(1);
-        }
-
-        // If we CAN find that workspace name in the JSON,
-        // then set it as the token for this session.
-        if (!!data[wsName]) {
-            token = data[wsName];
-        } else {
-            // Otherwise, warn the user and exit.
-            console.log(
-                `Couldn't find workspace [${wsName}] in ~/.slack_token.`
-            );
-            process.exit(1);
-        }
-    } catch (e) {
-        // Fall back to a file that contains only one token (for
-        // backwards compatibility)
-        token = tokenFileContents;
+    if (!!config.workspaces[wsName]) {
+        token = config.workspaces[wsName].token;
+    } else {
+        // Otherwise, warn the user and exit.
+        console.log(
+            `Couldn't find workspace [${wsName}] in ~/.slackadaisical.json. ` +
+            `Your options are: \n` +
+            Object.keys(config.workspaces).map(i => `* ${i}`).join("\n")
+        );
+        process.exit(1);
     }
 } catch (e) {
-    console.log("Could not find a slack token at " + tokenPath);
-    process.exit(1);
+    // Perhaps the user is using the old slack_token file?
+    console.log(
+        `Couldn't parse ~/.slackadaisical.json, falling back to ~/.slack_token.`
+    );
+    token = fs.readFileSync(tokenPath).toString().trim();
 }
+
 
 const app = new Slacker(token);
 app.init();


### PR DESCRIPTION
Invoke with `slackadaisical myWorkspace`, with a JSON file at `~/.slack_token` shaped like this:

```json
{
    "myWorkspace":        "xxx-slack-token-...",
    "myOtherWorkspace":   "xxx-slack-token-...",
}
```

Addresses #10 and (part of) #6.

Input and feedback very welcome!